### PR TITLE
fix(blog): correct date formatting in post component

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -42,7 +42,7 @@ export default async function Post(props: {
     'categories',
   ]);
 
-  const stringDate = new Date(post.date).toISOString().split('T');
+  const stringDate = new Date(post.date).toISOString().split('T')[0];
 
   return (
     <div className='container mx-auto px-4 py-4'>


### PR DESCRIPTION
The date string was incorrectly formatted, including the time part. This change ensures that only the date part is used by splitting the ISO string at 'T' and taking the first element.