### PR TITLE
feat(content): migrate posts from categories to tags frontmatter

### DIFF
--- a/content/AboutMe.md
+++ b/content/AboutMe.md
@@ -1,6 +1,8 @@
 ---
 slug: about
 date: 1970-01-01
+tags:
+  - blog/static
 ---
 
 I'm a seasoned programmer and tech consultant, specializing in Document Management, Process Automation, and Web Development. Proficient in Typescript, Javascript, and PHP.

--- a/content/An Old Post.md
+++ b/content/An Old Post.md
@@ -2,8 +2,8 @@
 title: An Old Post
 date: 2011-01-20
 slug: 810030d-msn-error
-categories:
-  - tech
+tags:
+  - blog/tech
 ---
 
 As I mentioned in the first post of this install, this blog has been installed and reinstalled lots of times.

--- a/content/Anaylysing My Forecasts.md
+++ b/content/Anaylysing My Forecasts.md
@@ -2,8 +2,8 @@
 title: Analysing My Forecasts
 date: 2011-06-21
 slug: analysing-my-forecasts
-categories:
-  - weather
+tags:
+  - blog/weather
 ---
 
 So I've now been predicting the weather for a week, and well all I can say is, I’m pretty damn good at it.

--- a/content/Be A Sheep.md
+++ b/content/Be A Sheep.md
@@ -2,9 +2,9 @@
 title: Be A Sheep
 date: 2014-10-16
 slug: be-a-sheep
-categories:
-  - rants
-  - tech
+tags:
+  - blog/rants
+  - blog/tech
 ---
 
 I was reading my friend Shane's [blog post](http://rainbowtrash.com/2014/10/15/why-forza-horizon-2-has-ruined-gaming-for-me/) on Forza Horizon, and how for him, it has ruined gaming for him, and it got me thinking about in general how we choose technology.

--- a/content/Code Highlighting with React Syntax Highlter.md
+++ b/content/Code Highlighting with React Syntax Highlter.md
@@ -2,9 +2,9 @@
 title: Code Highlighting In This Blog
 date: 2023-10-03
 slug: code-highlighting
-categories:
-  - tech
-  - typescript
+tags:
+  - blog/tech
+  - blog/typescript
 ---
 I decided to rewrite this entire website, migrating from WordPress to a static site generated in NextJS, partly because I wanted to have something more customisable and partly because I wanted to get away from WordPress.
 

--- a/content/Damn Daniel.md
+++ b/content/Damn Daniel.md
@@ -2,8 +2,8 @@
 title: Damn Snappeh, back at it again
 date: 2021-11-24
 slug: damn-snappeh-back-at-it-again
-categories:
-  - site-news
+tags:
+  - blog/site-news
 ---
 
 This blog once again has a new home with the same old content

--- a/content/Enough Is Enough Protest.md
+++ b/content/Enough Is Enough Protest.md
@@ -2,8 +2,8 @@
 title: I Gone Done a Protest
 date: 2014-11-17
 slug: enough-is-enough
-categories:
-  - politics
+tags:
+  - blog/politics
 ---
 
 This Sunday, was the date that a peaceful protest had been organised in Guernsey, against the introduction of some of the taxes that have recently been passed through our States government. It was titled 'Enough Is Enough' and was supposed to be middle earners expressing displeasure at the majority of newly formed taxes affecting them, when they are already operating on stretched budgets.

--- a/content/First RPA Tips.md
+++ b/content/First RPA Tips.md
@@ -2,9 +2,9 @@
 title: Steps for a Successful RPA First Implementation
 date: 2023-10-01
 slug: tips-for-a-sucessful-first-rpa
-categories:
-  - rpa
-  - tech
+tags:
+  - blog/rpa
+  - blog/tech
 ---
 
 ## The Problem

--- a/content/Guernsey Press IPV4 Article.md
+++ b/content/Guernsey Press IPV4 Article.md
@@ -2,8 +2,8 @@
 title: Technical Writing Fail - Guernsey Press
 date: 2011-02-28
 slug: ipv4-article-fail
-categories:
-  - rants
+tags:
+  - blog/rants
 ---
 
 I know that Jason was going to cover this on his blog over at [deedoubleyou.net](http://deedoubleyou.net), but he hasn’t. And this was posted on the 4th of February, back when the IPV4 exhaustion thing was current. So I thought I would write a little something about this before it's entirely outdated.
@@ -14,7 +14,7 @@ As an IT Professional/Technical person, reading this explanation was painful, to
 
 So without further ado, look after the break for a copy of the article, and my points after reading it.
 
-Oh, and Guernsey Press, keep away from technical writing for a bit please ![Guernsey Press IPV4 article - 4/2/11](/images/GPArticle.jpg) Please read through the article, on the bits that I have highlighted. You should be able to click on it, to get it full size. Then each of these numbered points below addresses my comments on that highlighted part.
+Oh, and Guernsey Press, keep away from technical writing for a bit please ![Guernsey Press IPV4 article - 4/2/11](./images/GPArticle.jpg) Please read through the article, on the bits that I have highlighted. You should be able to click on it, to get it full size. Then each of these numbered points below addresses my comments on that highlighted part.
 
 ## Fail 1 - Web Address
 

--- a/content/Guernsey VDSL Line Distance.md
+++ b/content/Guernsey VDSL Line Distance.md
@@ -2,8 +2,8 @@
 title: Distance != Quality
 date: 2011-02-11
 slug: distance-is-not-quality
-categories:
-  - rants
+tags:
+  - blog/rants
 ---
 
 After noticing some traffic to my previous post came from some google searches, I decided to search for these terms which brought me to the "I Like Fast Internet blog" at [https://www.fastinternetblog.uk](https://www.fastinternetblog.uk), specifically this post on ["Investigating Internet speeds in Guernsey](https://www.fastinternetblog.uk/?p=81)"

--- a/content/Guernsey VDSL Speeds.md
+++ b/content/Guernsey VDSL Speeds.md
@@ -2,8 +2,8 @@
 title: Guernsey VDSL Speeds
 date: 2014-10-23
 slug: guernsey-vdsl-speeds
-categories: 
-  - tech
+tags:
+  - blog/tech
 ---
 
 I have previously written some fairly scathing reviews on Guernsey Broadband and the providers based here, examples [here](http://snappeh.com/blog/guernsey-adsl-is-a-joke/), and [here](http://snappeh.com/blog/distance-is-not-quality/). However, when I moved house 8 months ago, I ended up pretty darn close to an MSAN box, and therefore decided to try their VDSL service.

--- a/content/Guess Whos Back.md
+++ b/content/Guess Whos Back.md
@@ -2,8 +2,8 @@
 title: Guess Who's Back
 date: 2014-10-16
 slug: guess-whos-back
-categories: 
-  - site-news
+tags:
+  - blog/site-news
 ---
 
 Probably for a fleeting visit, like a terrible father.

--- a/content/Home Server Journey.md
+++ b/content/Home Server Journey.md
@@ -2,8 +2,8 @@
 title: My Home Server Journey
 date: 2021-11-26
 slug: my-home-server-journey
-categories: 
-  - tech
+tags:
+  - blog/tech
 ---
 
 When I was young I was always wanting to tinker with stuff. I remember excitedly downloading an Ubuntu ISO, burning it to a CD, and installing it on an old Pentium PC that I had got from somewhere.

--- a/content/Installing PopOS!.md
+++ b/content/Installing PopOS!.md
@@ -2,8 +2,8 @@
 title: Pop! goes the install
 date: 2023-10-17
 slug: pop-goes-the-install
-categories: 
-  - tech
+tags:
+  - blog/tech
 ---
 I've been trapped in a Windows hole for a long time now, mainly for the desktop experience. I have been using mainly Debian on servers for a long time, but with edge hosting and Docker that is becoming fewer and far between, not that I am complaining about that as Docker has made the world a much simpler place. 
 

--- a/content/Is The Storm Coming?.md
+++ b/content/Is The Storm Coming?.md
@@ -2,9 +2,9 @@
 title: Is The Storm Coming? Plug
 date: 2011-03-15
 slug: is-the-storm-coming
-categories: 
-  - recommendations
-  - weather
+tags:
+  - blog/weather
+  - blog/recommendations
 ---
 
 Because I have little other content to put up, I'm just leaving a note about another website I run with Jason, [Is The Storm Coming](http://isthestormcoming.com)?.

--- a/content/Kinect Causing RROD.md
+++ b/content/Kinect Causing RROD.md
@@ -2,8 +2,8 @@
 title: Kinect Causes RROD
 date: 2011-01-07
 slug: blame-the-kinect
-categories: 
-  - gaming
+tags:
+  - blog/gaming
 ---
 
 According to the BBC "[Online gaming forums have also been buzzing with accounts of consoles showing the Red Ring of Death shortly after plugging in Kinects.](http://www.bbc.co.uk/news/technology-12121999)"

--- a/content/New Tech Availablity in Guernsey.md
+++ b/content/New Tech Availablity in Guernsey.md
@@ -2,9 +2,9 @@
 title: The Bleeding Edge - Guernsey Style
 date: 2014-10-17
 slug: the-bleeding-edge
-categories:
-  - rants
-  - tech
+tags:
+  - blog/rants
+  - blog/tech
 ---
 
 Something new has come out, something advanced. Normally a mobile phone of some description. There is one feature you can guarantee, which is a complete absence from any shelves in Guernsey.

--- a/content/Predicting The Weather.md
+++ b/content/Predicting The Weather.md
@@ -2,8 +2,8 @@
 title: Predicting the Weather
 date: 2011-06-14
 slug: predicting-the-weather
-categories:
-  - weather
+tags:
+  - blog/weather
 ---
 
 Predicting the weather is a difficult task, often taking years of training. Then hours of studying charts, tides to predict weather we are going to be wearing shorts or trousers tomorrow.  

--- a/content/Premature Windows.md
+++ b/content/Premature Windows.md
@@ -2,8 +2,8 @@
 title: Windows 8, This Soon?
 date: 2011-03-08
 slug: premature-windows
-categories: 
-  - tech
+tags:
+  - blog/tech
 ---
 
 I was reading a blog by Sam Bellis, [here](http://www.sambellis.com/?p=373), asking if we could see Windows 8 materials by June this year, and a post about a Windows 8 2012 release, [here](http://www.sambellis.com/?p=351).

--- a/content/Rant About ID Cards.md
+++ b/content/Rant About ID Cards.md
@@ -2,8 +2,8 @@
 title: Speaking to Nobody
 date: 2011-03-07
 slug: speaking-to-nobody
-categories:
-  - rants
+tags:
+  - blog/rants
 ---
 
 It is wonderful to have the right to speak out, but it is a shame people then have the right not to reply.

--- a/content/Rant about 8mb VDSL.md
+++ b/content/Rant about 8mb VDSL.md
@@ -2,8 +2,9 @@
 title: Sorry State of Guernsey Broadband
 date: 2011-02-03
 slug: guernsey-adsl-is-a-joke
-categories:
-  - rants
+tags:
+  - blog/tech
+  - blog/internet
 ---
 
 Well after reading my good friend Jason (deedoubleyou)'s blog post on the recent upgrade of Guernsey broadband [here](http://deedoubleyou.net/2011/02/01/guernsey-broadband/), I thought I would add my two cents. As I have found out this week, an upgrade to 8mb in Guernsey means an upgrade maybe, if you’re lucky By the way if you read the rest of the post, I really recommend Open DNS, I think it's great.

--- a/content/Rock, Paper, Scissors Bot.md
+++ b/content/Rock, Paper, Scissors Bot.md
@@ -2,9 +2,9 @@
 title: Rock, Paper, BSOD
 date: 2011-03-09
 slug: rock-paper-scissors-bot
-categories: 
-  - reviews
-  - tech
+tags:
+  - blog/reviews
+  - blog/tech
 ---
 
 Well interestingly the NY Times have released [a bot that plays Rock, Paper, Scissors](http://www.nytimes.com/interactive/science/rock-paper-scissors.html). As the website states:

--- a/content/Snapph Blog Begins Again.md
+++ b/content/Snapph Blog Begins Again.md
@@ -2,8 +2,8 @@
 title: Snappeh Blog Begins…Again
 date: 2010-12-01
 slug: here-we-go-again
-categories: 
-  - site-news
+tags:
+  - blog/site-news
 ---
 
 Well this is the 3rd WordPress installation at this URL.

--- a/content/Snow in Guernsey.md
+++ b/content/Snow in Guernsey.md
@@ -2,8 +2,8 @@
 title: Snow, in Guernsey
 date: 2010-12-01
 slug: snow-in-guernsey
-categories:
-  - weather
+tags:
+  - blog/weather
 ---
 
 Well, it's the 1st of December, and we have had small amount of snow in Guernsey. Enough for me to not want to drive to work, call me wet, but this is Guernsey. Snow is srsbsns

--- a/content/Tech Interview Cake Making.md
+++ b/content/Tech Interview Cake Making.md
@@ -2,8 +2,8 @@
 title: Whipping Up Tech Brilliance!
 date: 2023-10-20
 slug: whipping-up-tech-brilliance
-categories:
-  - tech
+tags:
+  - blog/tech
 ---
 
 A thought I have been having recently has to do with finding new raw talent in tech. How do you interview somebody who doesn't have a CV or a portfolio of work to show you? How do you find the next big thing? Don't get me wrong, I am not saying that you should hire somebody without any programming knowledge, but how do you find somebody who has the potential to be a great programmer?

--- a/content/Things I've Made.md
+++ b/content/Things I've Made.md
@@ -1,6 +1,8 @@
 ---
 slug: portfolio
 date: 1970-01-01
+tags:
+  - blog/static
 ---
 
 Some personal projects I have developed:

--- a/content/Windows 1 upgraded to 7.md
+++ b/content/Windows 1 upgraded to 7.md
@@ -2,8 +2,8 @@
 title: Windows 1 Upgraded To 7
 date: 2011-03-04
 slug: windows1-2-3-95-98-2000-xp-7
-categories: 
-  - tech
+tags:
+  - blog/tech
 ---
 
 Well you know how you always get told, don't do a Windows upgrade installation, and always to install from fresh.

--- a/content/Writers Block.md
+++ b/content/Writers Block.md
@@ -2,8 +2,8 @@
 title: Writer's Block
 date: 2014-10-20
 slug: writers-block
-categories: 
-  - rants
+tags:
+  - blog/rants
 ---
 
 After re-activating this blog for the 3rd or 4th time; I now remember why it goes neglected quite a lot.

--- a/content/iPhone 3GS Rebooting During Call.md
+++ b/content/iPhone 3GS Rebooting During Call.md
@@ -1,9 +1,9 @@
 ---
 title: iPhone 3GS Rebooting During Call
 date: 2011-02-24
-categories:
-  - tech
 slug: 3gs-reboots-in-call
+tags:
+  - blog/tech
 ---
 
 Today, one of the most senior people at work came to me with their iPhone 3gs which they claimed would reboot approximately 5-10 minutes into a call.

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -39,7 +39,7 @@ export default async function Post(props: {
     'date',
     'slug',
     'content',
-    'categories',
+    'tags',
   ]);
 
   const stringDate = new Date(post.date).toISOString().split('T')[0];
@@ -54,15 +54,15 @@ export default async function Post(props: {
           <h1 className='text-3xl font-bold text-gray-100'>{post.title}</h1>
           <p className='mb-4 text-sm text-gray-100'>{stringDate}</p>
 
-          {post.categories && (
+          {post.tags && (
             <p className='text-gray-100'>
-              <span className='mr-2'>Categories</span>
-              {post.categories.map((category: string) => (
+              <span className='mr-2'>Tags</span>
+              {post.tags.map((tag: string) => (
                 <span
-                  key={category}
+                  key={tag}
                   className='mr-2 inline-block rounded-full border-t-white bg-gray-200 px-3 py-1 text-sm font-semibold text-gray-700'
                 >
-                  {category}
+                  {tag}
                 </span>
               ))}
             </p>


### PR DESCRIPTION
- Replace all `categories` frontmatter fields with `tags` in Markdown content.
- Prefix all tags with `blog/` for consistency.
- Update post rendering to use `tags` instead of `categories`.
- Update post filtering logic to exclude posts with `blog/static` tag.
- Adjust post listing and pagination to use tags for filtering and display.